### PR TITLE
Allow specifying PAT scope as a command-line argument in rotation command

### DIFF
--- a/pat.py
+++ b/pat.py
@@ -360,7 +360,7 @@ class RotationCommandBase:
         tokens = {}
         for org in orgs:
             name = format_pat_name(prefix=prefix, org=org)
-            pat = create_pat(org, name, 'vso.packaging_write', expiration)
+            pat = create_pat(org, name, args.scope, expiration)
             tokens[org] = pat['token']
             print(f'Created PAT {pat["displayName"]!r} valid to '
                   f'{pat["validTo"]}')
@@ -393,7 +393,13 @@ class RotationCommandBase:
             '--prefix',
             help='PAT name prefix',
             default=self.pat_prefix)
-
+        parser.add_argument(
+            '--scope',
+            metavar='SCOPE',
+            help='PAT scope (see https://learn.microsoft.com/en-us/azure/'
+            'devops/integrate/get-started/authentication/oauth?view=azure-'
+            'devops#scopes for more information)',
+            default='vso.packaging_write')
 
 class MavenCommand(RotationCommandBase, CommandRegistry):
     command_name = 'maven'


### PR DESCRIPTION
We have a scenario where we want to add more scopes to the PAT acquired in the "maven" command, for example.

With this change, one can specify custom scopes to any command that involves rotation of PAT, similar to how "create" already does it.

The default (current) behavior is unchanged.